### PR TITLE
Componentize app with Minidux

### DIFF
--- a/components/help/index.js
+++ b/components/help/index.js
@@ -1,0 +1,26 @@
+var intro = require('intro.js')
+
+module.exports = Help
+
+function Help (el, clickHandler) {
+  if (!(this instanceof Help)) return new Help(el)
+  this.$el = document.getElementById(el)
+  this.$el.onclick = function () {
+    var _intro = intro.introJs()
+    _intro.setOptions({
+      steps: [{
+        intro: 'You can create a new hyperdrive by clicking <b>Reset</b>'
+      },
+      {
+        intro: 'Drop some files here',
+        element: '#help-text'
+      },
+      {
+        intro: 'You can share the hyperdrive with this link',
+        element: 'input#share-link',
+        position: 'bottom'
+      }
+    ]})
+    _intro.start()
+  }
+}

--- a/components/hyperdrive-size/index.js
+++ b/components/hyperdrive-size/index.js
@@ -1,0 +1,37 @@
+var yo = require('yo-yo')
+var prettyBytes = require('pretty-bytes')
+
+module.exports = HyperdriveSize
+
+function HyperdriveSize (el) {
+  if (!(this instanceof HyperdriveSize)) return new HyperdriveSize(el)
+  var self = this
+  this.$el = document.getElementById(el)
+  this._component = this._render()
+  this._size = 0
+
+  if (this.$el) this.$el.appendChild(this._component)
+}
+
+HyperdriveSize.prototype.update = function (state) {
+  if (state && state.archiveReducer) {
+    this._updateSize(state)
+    yo.update(this._component, this._render())
+  }
+}
+
+HyperdriveSize.prototype._render = function () {
+  var size = this._size
+  var component = yo`<p id="size">Drive size: ${size}</p>`
+  return component
+}
+
+HyperdriveSize.prototype._updateSize = function (state) {
+  if (state.archiveReducer) {
+    var s = state.archiveReducer
+    if (s.archive &&  s.archive.content && s.archive.content.bytes) {
+      return this._size = prettyBytes(s.archive.content.bytes)
+    }
+    else { return this._size = 0 }
+  }
+}

--- a/components/hyperdrive-size/test.js
+++ b/components/hyperdrive-size/test.js
@@ -1,0 +1,1 @@
+/* unit test stub */

--- a/components/index.js
+++ b/components/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  Help: require('./help'),
+  HyperdriveSize: require('./hyperdrive-size'),
+  Peers: require('./peers'),
+  ResetButton: require('./reset-button'),
+  SpeedDisplay: require('./speed-display')
+}
+
+

--- a/components/peers/index.js
+++ b/components/peers/index.js
@@ -1,0 +1,34 @@
+var yo = require('yo-yo')
+
+module.exports = Peers
+
+function Peers (el) {
+  if (!(this instanceof Peers)) return new Peers(el)
+  var self = this
+  this.$el = document.getElementById(el)
+  this._component = this._render()
+  this._peers = 0;
+
+  if (this.$el) this.$el.appendChild(this._component)
+}
+
+Peers.prototype.update = function (state) {
+  if (state && state.peersReducer) {
+    this._updateNumPeers(state)
+    yo.update(this._component, this._render())
+  }
+}
+
+Peers.prototype._render = function () {
+  var peers = this._peers || 0
+  var pl = peers > 1 || peers === 0 ? 's' : ''
+  var component = yo`<span>${peers} Source${pl}</span>`
+  return component
+}
+
+Peers.prototype._updateNumPeers = function (state) {
+  if (state.peersReducer && state.peersReducer.peers) {
+    return this._peers = state.peersReducer.peers
+  }
+  else { return this._peers = 0 }
+}

--- a/components/reset-button/index.js
+++ b/components/reset-button/index.js
@@ -1,0 +1,10 @@
+module.exports = ResetButton
+
+function ResetButton (el, clickHandler) {
+  if (!(this instanceof ResetButton)) return new ResetButton(el, clickHandler)
+  var self = this
+  this.$el = document.getElementById(el)
+  this.$el.onclick = function () {
+    clickHandler(null)
+  }
+}

--- a/components/speed-display/index.js
+++ b/components/speed-display/index.js
@@ -1,0 +1,73 @@
+var yo = require('yo-yo')
+var speedometer = require('speedometer')
+var prettyBytes = require('pretty-bytes')
+
+module.exports = SpeedDisplay
+
+function SpeedDisplay (el, store) {
+  if (!(this instanceof SpeedDisplay)) return new SpeedDisplay(el)
+  this.$el = document.getElementById(el)
+  this._archiveKey
+  this._timer
+  this._uploadSpeedometer = speedometer(3)
+  this._downloadSpeedometer = speedometer(3)
+  this._upload
+  this._download
+  this._component = this._render()
+
+  if (this.$el) this.$el.appendChild(this._component)
+}
+
+SpeedDisplay.prototype.update = function (state) {
+  if (state && state.archiveReducer) {
+    this._attachHandlers(state)
+  }
+}
+
+SpeedDisplay.prototype._render = function () {
+  var self = this
+  window.clearTimeout(this._timer)
+  this._timer = window.setTimeout(function () {
+    self.$el.style.display = 'none'
+    self._download = 0;
+    self._upload = 0;
+  }, 1500)
+
+  var down = this._download
+  var up = this._upload
+  var component = yo`<span>speed:
+                     <span id="download-speed">download: ${down}</span>
+                     <span id="upload-speed">upload: ${up}</span>
+                     </span>`
+
+  if (down || up) this.$el.style.display = 'block'
+  return component
+}
+
+SpeedDisplay.prototype._attachHandlers = function (state) {
+  var self = this
+  if (state && state.archiveReducer) {
+    var s = state.archiveReducer
+    if (s.archive && s.archive.key.toString('hex') !== this._archiveKey) {
+      this._archiveKey = s.archive.key.toString('hex')
+
+      s.archive.on('upload', function (data) {
+        self._calculate('upload', data)
+      })
+      s.archive.on('download', function (data) {
+        self._calculate('download', data)
+      })
+    }
+  }
+}
+
+SpeedDisplay.prototype._calculate = function (direction, data) {
+  if (!data.length) return
+  var speedometerPropName = '_' + direction + 'Speedometer'
+  var bytesPerSecond = this[speedometerPropName](data.length)
+  if (bytesPerSecond) {
+    var propName = '_' + direction
+    this[propName] = prettyBytes(bytesPerSecond)
+    yo.update(this._component, this._render())
+  }
+}

--- a/index.html
+++ b/index.html
@@ -12,10 +12,7 @@
         <h3 id="peers"></h3>
         <button id="help" class="button">?</button>
         <button id="new" class="button">Reset</button>
-        <h3 id="speed">speed:
-          <span id="download-speed"></span>
-          <span id="upload-speed"></span>
-        </h3>
+        <h3 id="speed"></h3>
       </div>
     </header>
     <div class="status-bar">
@@ -23,6 +20,7 @@
     </div>
     <main class="site-main">
       <div class="container">
+        <div id="hyperdrive-size"></div>
         <!-- <div class="upload-file">Drop Files</div> -->
         <div id="hyperdrive-ui"></div>
       </div>

--- a/index.js
+++ b/index.js
@@ -7,14 +7,29 @@ var choppa = require('choppa')
 var swarm = require('hyperdrive-archive-swarm')
 var db = level('./dat.db')
 var drive = hyperdrive(db)
-var speedometer = require('speedometer')
-var prettyBytes = require('pretty-bytes')
 var path = require('path')
-var intro = require('intro.js')
 var explorer = require('hyperdrive-ui')
 
 var $hyperdrive = document.querySelector('#hyperdrive-ui')
 var $shareLink = document.getElementById('share-link')
+
+var componentCtors = require('./components')
+var components = [
+  componentCtors.Help('help'),
+  componentCtors.HyperdriveSize('hyperdrive-size'),
+  componentCtors.Peers('peers'),
+  componentCtors.ResetButton('new', main),
+  componentCtors.SpeedDisplay('speed'),
+]
+
+var store = require('./store')
+store.subscribe(function (state) {
+  for (var c in components) {
+    if (components[c].update) {
+      components[c].update(state)
+    }
+  }
+})
 
 var keypath = window.location.hash.substr(1).match('([^/]+)(/?.*)')
 var key = keypath ? keypath[1] : null
@@ -23,6 +38,7 @@ var cwd = '/'
 
 if (file) {
   getArchive(key, function (archive) {
+    store.dispatch({ type: 'INIT_ARCHIVE', archive: archive })
     archive.createFileReadStream(file).pipe(concat(function (data) {
       document.write(data)
     }))
@@ -32,48 +48,19 @@ if (file) {
   main(key)
 }
 
-function updatePeers (peers) {
-  if (!peers) peers = 0
-  document.querySelector('#peers').innerHTML = peers + ' source' + (peers > 1 || peers === 0 ? 's' : '')
-}
-
 function getArchive (key, cb) {
   var archive = drive.createArchive(key, {live: true})
   var sw = swarm(archive)
   sw.on('connection', function (peer) {
-    updatePeers(sw.connections)
+    store.dispatch({ type: 'UPDATE_PEERS', peers: sw.connections })
     peer.on('close', function () {
-      updatePeers(sw.connections)
+      store.dispatch({ type: 'UPDATE_PEERS', peers: sw.connections })
     })
   })
   archive.open(function () { cb(archive) })
-  attachSpeedometer(archive)
-}
-
-document.querySelector('#help').onclick = function () {
-  var introjs = intro.introJs()
-  introjs.setOptions({
-    steps: [
-      {
-        intro: 'You can create a new hyperdrive by clicking <b>Reset</b>'
-      },
-      {
-        intro: 'Drop some files here',
-        element: '#help-text'
-      },
-      {
-        intro: 'You can share the hyperdrive with this link',
-        element: 'input#share-link',
-        position: 'bottom'
-      }
-    ]})
-  introjs.start()
 }
 
 function main (key) {
-  var button = document.querySelector('#new')
-  button.onclick = function () { main(null) }
-
   var help = document.querySelector('#help-text')
   help.innerHTML = 'looking for sources …'
   $hyperdrive.innerHTML = ''
@@ -93,6 +80,7 @@ function main (key) {
     }
     var tree = explorer(archive, onclick)
     $hyperdrive.appendChild(tree)
+    store.dispatch({ type: 'INIT_ARCHIVE', archive: archive })
   })
 }
 
@@ -110,8 +98,10 @@ function installDropHandler (archive) {
       loop()
 
       function loop () {
-        if (i === files.length) return console.log('added files to ', archive.key.toString('hex'), files)
-
+        if (i === files.length) {
+          store.dispatch({ type: 'UPDATE_ARCHIVE', archive: archive })
+          return console.log('added files to ', archive.key.toString('hex'), files)
+        }
         var file = files[i++]
         var stream = fileReader(file)
         var entry = {name: path.join(cwd, file.fullPath), mtime: Date.now(), ctime: Date.now()}
@@ -123,34 +113,4 @@ function installDropHandler (archive) {
       window.alert('You are not the owner of this drive.  Click "Reset" to create a new drive.')
     })
   }
-}
-
-function attachSpeedometer (archive) {
-  var speed = speedometer(1)
-  var $els = {
-    speed: document.getElementById('speed'),
-    upload: document.getElementById('upload-speed'),
-    download: document.getElementById('download-speed')
-  }
-  var timer
-  function update (direction, data) {
-    if (!data.length) return
-    var bytesPerSecond = speed(data.length)
-    if (bytesPerSecond && $els[direction]) {
-      $els.speed.style.display = 'block'
-      $els[direction].innerHTML = direction + ' ' + prettyBytes(bytesPerSecond)
-      window.clearTimeout(timer)
-      timer = window.setTimeout(function () {
-        $els.speed.style.display = 'none'
-        $els.upload.innerHTML = ''
-        $els.download.innerHTML = ''
-      }, 1500)
-    }
-  }
-  archive.on('upload', function (data) {
-    update('upload', data)
-  })
-  archive.on('download', function (data) {
-    update('download', data)
-  })
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "intro.js": "^2.1.0",
     "level-browserify": "^1.1.0",
     "memdb": "^1.3.1",
+    "minidux": "^1.0.1",
     "pretty-bytes": "^3.0.1",
     "speedometer": "^1.0.0",
     "standard": "^7.1.2",

--- a/static/style.css
+++ b/static/style.css
@@ -127,7 +127,7 @@ a:hover, a:focus,
   width: 320px;
 }
 
-#speed span {
+#speed span span {
   font-weight: normal;
   font-size: 13px;
   line-height: 37px;

--- a/store.js
+++ b/store.js
@@ -1,0 +1,23 @@
+var minidux = require('minidux')
+
+function archiveReducer (state, action) {
+  if (state === undefined) state = { archive: undefined }
+  if (action.type === 'INIT_ARCHIVE' || action.type === 'UPDATE_ARCHIVE') {
+    return  { archive: action.archive }
+  }
+}
+
+function peersReducer (state, action) {
+  if (state === undefined) state = { peers: 0 }
+  if (action.type === 'UPDATE_PEERS') {
+    return { peers: action.peers }
+  }
+}
+
+var reducers = minidux.combineReducers({
+  archiveReducer,
+  peersReducer
+})
+var store = minidux.createStore(reducers);
+
+module.exports = store


### PR DESCRIPTION
So I found a great article that neatly explains why Minidux is a great tool for componentizing the app (Minidux is a pared down version of Redux):
https://css-tricks.com/learning-react-redux/

The basic idea is that we want a single source of truth for our app state that the components can dynamically subscribe to, rather than all the chaos of one component notifying another that something happened, and then the 2nd notifying a 3rd, and so and so on as commonly happens as browser apps complexify. Do read that article^^. Minidux is awesome and fixes this problem efficiently and effectively.

I went ahead and componentized the first few sample pieces that needed it, next week I (or someone else) can finish up so that the *only* logic in index.js (our app logic) is main() and getArchive() -- and of course the component callbacks for subscribing to state changes. Everything else in index.js should become a component IMO, whether it makes use of state or not (ResetButton does not, for example).

The pattern I've arrived at since Minidux only allows for ONE subscriber you can see at index.js, lines 17-32. Each of the components is init'd and pushed into an array. Then, when a state change dispatch to Minidux happens via store.dispatch(), the subscriber on index.js line 26 walks through each component looking for a component method on each called update(). If update() is present on the component, that means it wants to be notified of an application state change and contains internal handlers for doing so. 

Honestly, this is so lightweight and awesome for what its giving us, I am really stoked on it. If it takes a minute to wrap head around, its worth it. ++++ Props again to authors of Yo-Yo and Minidux! ++++
