### PR TITLE
Use Sparse mode so files are downloaded individually

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "filereader-stream": "^1.0.0",
     "gh-pages-deploy": "^0.4.2",
     "http-server": "^0.9.0",
-    "hyperdrive": "^6.2.1",
+    "hyperdrive": "^6.6.1",
     "hyperdrive-archive-swarm": "^3.0.1",
     "hyperdrive-ui": "^2.0.0",
     "intro.js": "^2.1.0",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -49,7 +49,7 @@ if (file) {
 }
 
 function getArchive (key, cb) {
-  var archive = drive.createArchive(key, {live: true})
+  var archive = drive.createArchive(key, {live: true, sparse: true})
   var sw = swarm(archive)
   sw.on('connection', function (peer) {
     store.dispatch({ type: 'UPDATE_PEERS', peers: sw.connections })


### PR DESCRIPTION
closes https://github.com/karissa/hyperdrive-ui/issues/56

followup issues are https://github.com/karissa/hyperdrive-ui/issues/49 and https://github.com/datproject/dat.land/issues/112