### PR TITLE
use shipit for 2-command deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 debug.html
+version.txt
 node_modules/
 data/*
 public/css/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 data/*
 public/css/*
 public/js/*
+.tmp-deploy
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -28,3 +28,23 @@ npm run minify
 npm run version
 ```
 
+### using shipit for deployment and install
+[shipit](https://github.com/shipitjs/shipit) and [shipit-deploy](https://github.com/shipitjs/shipit-deploy) depends on rsync version 3+, git version 1.7.8+, and OpenSSH version 5+. To upgrade rsync on a macosx machine, [follow instructions here](https://static.afp548.com/mactips/rsync.html) (see "compile rsync 3.0.7" section).
+
+install shipit-cli locally, globally:
+```
+npm install shipit-cli -g
+```
+
+the config file is `shipitfile.js`. you'll need to set the environment var `DATLAND_USER` in your local shell for it to know which account to use to access the server.
+
+to test your access to machine via shipit:
+```
+shipit staging pwd
+```
+
+to deploy and install a build (note that shipit pulls build source from github):
+```
+shipit staging deploy
+shipit staging install
+```

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ npm install shipit-cli -g
 
 the config file is `shipitfile.js`. you'll need to set the environment var `DATLAND_USER` in your local shell for it to know which account to use to access the server.
 
-to test your access to machine via shipit:
+to test your access to machine via shipit from your local command line, call shipit, then the environment (in this case `uat`, which is tracking the master branch), then the actual command which corresponds to tasks defined in the shipitfile:
 ```
-shipit staging pwd
+shipit uat pwd
 ```
 
 to deploy and install a build (note that shipit pulls build source from github):
 ```
-shipit staging deploy
-shipit staging install
+shipit uat deploy
+shipit uat install
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We were recently awarded a [$420,000 grant by the Knight Foundation](http://www.
 ### develop
 ```
 npm run build
-npm start
+npm run dev
 ```
 
 To watch for scss changes and build css as you go (in a separate terminal):

--- a/bin/git-sha.js
+++ b/bin/git-sha.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+var fs = require('fs')
+var sha = require('git-sha')
+
+sha(function (err, gitSha) {
+  var print
+  if (err) print = 'git sha: error'
+  if (!err) print = 'git sha: ' + gitSha
+  fs.writeFileSync('version.txt', print, 'utf8')
+  console.log('Git sha written to version.txt:\n  ' + print)
+})

--- a/bin/version-assets.js
+++ b/bin/version-assets.js
@@ -10,7 +10,7 @@ var index = fs.readFileSync('index.html', 'utf8')
 fs.renameSync('index.html', 'debug.html')
 var prod = index
              .replace(/public\/css\/main.css/gmi, 'public/css/main.min.css')
-             .replace(/public\/js\/app.js/gmi, 'public/css/app.min.js')
+             .replace(/public\/js\/app.js/gmi, 'public/js/app.min.js')
 fs.writeFileSync('index.html', prod, 'utf8')
 
 // version `app.min.js` and `main.min.js` by appending md5 hash to filename

--- a/index.html
+++ b/index.html
@@ -29,6 +29,6 @@
         <div id="hyperdrive-ui"></div>
       </div>
     </main>
-    <script type="text/javascript" src="public/css/app.js"></script>
+    <script type="text/javascript" src="public/js/app.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <link rel="icon" type="image/png" href="public/images/dat-data-blank.png" />
-    <link rel="stylesheet" type="text/css" href="public/css/main.min.0793de4bac1496f5bfbd582a620fc840.css"/>
+    <link rel="stylesheet" type="text/css" href="public/css/main.css"/>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/2.1.0/introjs.min.css"/>
   </head>
   <body>
@@ -29,6 +29,6 @@
         <div id="hyperdrive-ui"></div>
       </div>
     </main>
-    <script type="text/javascript" src="public/css/app.min.4fc13df6e4f69af76563a96824958bec.js"></script>
+    <script type="text/javascript" src="public/css/app.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <link rel="icon" type="image/png" href="public/images/dat-data-blank.png" />
-    <link rel="stylesheet" type="text/css" href="public/css/main.css"/>
+    <link rel="stylesheet" type="text/css" href="public/css/main.min.0793de4bac1496f5bfbd582a620fc840.css"/>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/2.1.0/introjs.min.css"/>
   </head>
   <body>
@@ -29,6 +29,6 @@
         <div id="hyperdrive-ui"></div>
       </div>
     </main>
-    <script type="text/javascript" src="public/js/app.js"></script>
+    <script type="text/javascript" src="public/css/app.min.4fc13df6e4f69af76563a96824958bec.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "minify": "npm run minify-css && npm run minify-js",
     "minify-css": "minify public/css/main.css > public/css/main.min.css",
     "minify-js": "uglifyjs public/js/app.js -o public/js/app.min.js",
-    "version": "./bin/version-assets.js"
+    "version": "./bin/git-sha.js && ./bin/version-assets.js"
   },
   "author": "Karissa McKelvey <karissa@karissamck.com> (http://karissamck.com/)",
   "license": "MIT",
@@ -30,6 +30,7 @@
     "es2020": "^1.1.7",
     "filereader-stream": "^1.0.0",
     "gh-pages-deploy": "^0.4.2",
+    "git-sha": "^1.0.0",
     "http-server": "^0.9.0",
     "hyperdrive": "^6.2.1",
     "hyperdrive-archive-swarm": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "dat-land",
   "version": "1.2.3",
   "description": "An online place for dats.",
+  "license": "MIT",
   "main": "src/js/app.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/datproject/dat.land.git"
+  },
+  "bugs": {
+    "url": "https://github.com/datproject/dat.land/issues"
+  },
   "scripts": {
     "dev": "npm run watch && npm start",
     "start": "http-server .",
@@ -19,14 +27,12 @@
     "minify-js": "uglifyjs public/js/app.js -o public/js/app.min.js",
     "version": "./bin/git-sha.js && ./bin/version-assets.js"
   },
-  "author": "Karissa McKelvey <karissa@karissamck.com> (http://karissamck.com/)",
-  "license": "MIT",
   "devDependencies": {
     "brfs": "^1.4.3",
     "browserify": "^12.0.0",
     "choppa": "^1.0.2",
     "concat-stream": "^1.5.1",
-    "dat-design": "^1.1.0",
+    "dat-design": "^1.2.5",
     "drag-drop": "^2.11.0",
     "es2020": "^1.1.7",
     "filereader-stream": "^1.0.0",
@@ -45,6 +51,7 @@
     "node-sass-magic-importer": "^0.1.4",
     "node-version-assets": "^1.1.0",
     "pretty-bytes": "^3.0.1",
+    "shipit-deploy": "^2.2.0",
     "speedometer": "^1.0.0",
     "standard": "^7.1.2",
     "uglify-js": "^2.7.0",
@@ -52,12 +59,5 @@
     "wzrd": "^1.3.1",
     "yo-yo": "^1.2.2",
     "yo-yoify": "^3.1.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/karissa/hyperdrive-ui.git"
-  },
-  "bugs": {
-    "url": "https://github.com/karissa/hyperdrive-ui/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An online place for dats.",
   "main": "src/js/app.js",
   "scripts": {
-    "start": "npm run watch & http-server .",
+    "dev": "npm run watch && npm start",
+    "start": "http-server .",
     "lint": "standard",
     "test": "standard",
     "watch": "npm run watch-js",

--- a/shipitfile.js
+++ b/shipitfile.js
@@ -11,9 +11,10 @@ module.exports = function (shipit) {
       rsync: ['--del'],
       keepReleases: 2
     },
-    staging: {
+    uat: {
       servers: process.env.DATLAND_USER + '@dat.land',
-      deployTo: 'src/dat.land/staging'
+      deployTo: 'src/dat.land/uat',
+      branch: 'master'
     }
   })
 

--- a/shipitfile.js
+++ b/shipitfile.js
@@ -1,0 +1,32 @@
+var pkg = require('./package.json')
+
+module.exports = function (shipit) {
+  require('shipit-deploy')(shipit)
+
+  shipit.initConfig({
+    default: {
+      workspace: './.tmp-deploy',
+      repositoryUrl: pkg.repository.url,
+      ignores: ['.git', 'node_modules'],
+      rsync: ['--del'],
+      keepReleases: 2
+    },
+    staging: {
+      servers: process.env.DATLAND_USER + '@dat.land',
+      deployTo: 'src/dat.land/staging'
+    }
+  })
+
+  shipit.task('pwd', function () {
+    return shipit.remote('pwd')
+  })
+
+  shipit.task('install', function () {
+    var current = shipit.config.deployTo + '/current'
+    shipit.log('running `shipit install` in remote ' + current)
+    return shipit.remote(
+      'cd ' + current +
+      ' && npm install && npm run build && npm run minify && npm run version'
+    )
+  })
+}


### PR DESCRIPTION
shipit is a lightweight capistrano. it has been tuned here to deploy to just the staging env for now. see readme and shipitfile.js for details.

note that the npm scripts have been rejiggered and you'll want to use `npm run dev` for development (where you would have used `npm start` before).

