### PR TITLE
Style dat details header

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <div id="header"></div>
     <div class="dat-info-header" id="dat-info">
       <div class="container">
-        <div id="share-link"></div>
+        <div id="share-link" class="share-link"></div>
         <div id="permissions"></div>
         <div id="hyperdrive-size"></div>
         <div id="peers"></div>

--- a/index.html
+++ b/index.html
@@ -9,10 +9,12 @@
     <div class="dat-info-header" id="dat-info">
       <div class="container">
         <div id="share-link" class="share-link"></div>
-        <div id="permissions"></div>
-        <div id="hyperdrive-size"></div>
-        <div id="peers"></div>
-        <div id="speed"></div>
+        <div class="dat-details">
+          <div id="permissions" class="dat-detail"></div>
+          <div id="hyperdrive-size" class="dat-detail"></div>
+          <div id="peers" class="dat-detail"></div>
+          <div id="speed" class="dat-detail"></div>
+        </div>
       </div>
     </div>
     <main class="site-main">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
           <div id="permissions" class="dat-detail"></div>
           <div id="hyperdrive-size" class="dat-detail"></div>
           <div id="peers" class="dat-detail"></div>
-          <div id="speed" class="dat-detail"></div>
+          <div id="speed" class="dat-detail dat-detail--speed"></div>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <div id="header"></div>
-    <div class="dat-info-header" id="dat-info">
+    <div class="dat-header" id="dat-info">
       <div class="container">
         <div id="share-link" class="share-link"></div>
         <div class="dat-details">

--- a/index.html
+++ b/index.html
@@ -6,22 +6,26 @@
   </head>
   <body>
     <div id="header"></div>
+    <div class="dat-info-header" id="dat-info">
+      <div class="container">
+        <div id="share-link"></div>
+        <div id="permissions"></div>
+        <div id="hyperdrive-size"></div>
+        <div id="peers"></div>
+        <div id="speed"></div>
+      </div>
+    </div>
     <main class="site-main">
       <div class="container">
-        <div id="dat-info">
-          <div id="share-link"></div>
-          <div id="permissions"></div>
-          <div id="hyperdrive-size"></div>
-          <div id="peers"></div>
-          <div id="speed"></div>
-        </div>
         <div id="file-queue"></div>
         <div id="hyperdrive-ui"></div>
       </div>
     </main>
     <div class="status-bar">
-      <span id="help-text">Initializing</span>
-      <div id="hyperdrive-stats"></div>
+      <div class="container">
+        <span id="help-text" class="status-bar-status">Initializing</span>
+        <div id="hyperdrive-stats" class="status-bar-stats"></div>
+      </div>
     </div>
     <script type="text/javascript" src="public/js/app.js"></script>
   </body>

--- a/src/js/components/header/index.js
+++ b/src/js/components/header/index.js
@@ -21,11 +21,11 @@ Header.prototype.update = function (state) {
 
 Header.prototype._render = function () {
   return yo`
-    <header class="dat-header">
+    <header class="site-header">
       <a href="http://dat-data.com" class="dat-logo">
         <img src="./public/img/dat-data-logo.svg" style="width:40px;" />
       </a>
-      <div class="dat-header__actions">
+      <div class="site-header__actions">
         <div class="dat-button">
           ${button({
             text: 'Create new Dat',

--- a/src/scss/dat-header.scss
+++ b/src/scss/dat-header.scss
@@ -1,0 +1,25 @@
+// header for a single dat
+
+.dat-header {
+  background-color: $color-neutral--04;
+  border-bottom: 1px solid $color-neutral--10;
+  font-size: .8125rem;
+}
+
+.share-link {
+  font-size: 1.375rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dat-details {
+  padding-top: 1.5rem;
+  padding-bottom: .25rem;
+}
+
+.dat-detail {
+  display: inline-block;
+  margin-right: 1.5rem;
+  color: $color-neutral--80;
+}

--- a/src/scss/dat-header.scss
+++ b/src/scss/dat-header.scss
@@ -23,3 +23,17 @@
   margin-right: 1.5rem;
   color: $color-neutral--80;
 }
+
+.dat-detail--speed {
+  display: none;
+  float: right;
+  line-height: 37px;
+  margin: 0 10px 0 0px;
+  padding: 0;
+  width: 320px;
+  span {
+    font-weight: normal;
+    font-size: .8125rem;
+    line-height: 37px;
+  }
+}

--- a/src/scss/file-queue.scss
+++ b/src/scss/file-queue.scss
@@ -1,0 +1,22 @@
+/* file queue */
+
+#file-queue {
+  clear: both;
+  li {
+    padding: 10px;
+    padding-left: 35px;
+    font-size: 14px;
+    color: $color-neutral--50;
+    border-bottom: 1px solid #f0f0f0;
+    background-color: $color-neutral--04;
+    .progress {
+      float: right;
+      width: 30%;
+      &.error {
+        color: $color-danger;
+        text-align: right;
+        padding: 0;
+      }
+    }
+  }
+}

--- a/src/scss/file-system.scss
+++ b/src/scss/file-system.scss
@@ -1,0 +1,63 @@
+/* archive ui */
+
+#hyperdrive-ui {
+  clear: both;
+}
+
+#yo-fs {
+  color: $color-neutral;
+  padding: 0;
+  h1 a {
+    margin: 5px;
+  }
+  ul {
+    margin: 0;
+    padding: 0;
+  }
+  li {
+    list-style-type: none;
+    a {
+      display: block;
+      padding: 10px;
+      font-size: 14px;
+      border-bottom: 1px solid $color-neutral--20;
+      background-size: 15px;
+      background-repeat: no-repeat;
+      background-position: 10px 11px;
+      padding-left: 35px;
+      color: $color-neutral;
+      text-decoration: none;
+      &:hover {
+        background-color: $color-neutral--04;
+      }
+    }
+  }
+  .file a {
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEwAACxMBAJqcGAAABQZJREFUeJzt3M9rnEUcx/HPzPNskk3TTTZNVFQKIkIOEnr3pBQv2osiuKWpJ1Ei4kF7EPwnPIiIt5jmLPQkpV1wS089ay6ihJCy+dHEza/dZ/PMeEilYos2mZmdZ/f7eR1DmOfL5s3u7LOzAYiIiIhIHBVy8fqdOxeM0a9bixkoNQFlk5DXi2F9Z+uny5cufR97jtMKEsCtxt33APsVoGdDrF8kyyt/2Gpl7KN+jcBrAI1Go5ohXQDwts91i2x55XcAqm8j0L4WqtfvTXVs+jME/fEfsWq7tffd0o0bH8ae5KS8BFCv19OjtPujUnjVx3r9qT8j8BKASUe+0MBrPtbqb/0XgXMAN2/eG4cxX/oYZjD0VwTOAaiR7H1oXfExzODonwjcAzDqLR+DDJ7+iMB9D6DNBQ9zDKjiR+AcgDF4zscgg6vYETgHoLUu+RhksBU3Am83guj/FDMCBtBTxYuAAfRcsSJgAFEUJwIGEE0xImAAUcWPgAFEFzcCBlAI8SJgAIURJwIGUCi9j4ABONLK90PY2wgYgKNSmgZYtXcRMABH5aHhQCv3JgIG4Ojs6JmAq4ePgAE4OlMuY7g0FPAKYSNgAB48Wz0X+ArhImAAHoyOjGBqvBr4KmEiYACeTI1P4NzZ8cBX8R8BA/BoujqJ56emkeiQX4L2GwED8KwyOoaXX3gRz0xUMRRsc+gvghB3McTTSmOyMoHJygSO8hzZURd5bgBYn5dRsPgagNM3khlAYGmSIE2CvSSUXRfgS4BwDEA4BiBc9D1A62Av9ghRVUbHol4/egBrmxuxR4iqcj5uAHwJEI4BCMcAhGMAwkXfBM6cfyn2CKLxGUA4BiAcAxCOAQjHAIRjAMIxAOEYgHAMQLjodwJ5HoDnAWKPEBXPA1BUDEA4BiAcAxAu+iaQ5wHi4jOAcAxAOAYgHAMQjgEIxwCEYwDCMQDhGIBw0e8E8jwAzwPEHiEqngegqBiAcAxAOAYgXPRNIM8DxMVnAOEYgHAMQDgGIBwDEI4BCMcAhGMAwjEA4aLfCeR5AJ4HiD1CVDwPQFExAOEYgHAMQLjom0CeB4iLzwDCMQDhGIBwDEA4BiAcAxCOAQjHAIRjAMIxAOEYgHAMQDgGIBwDEI4BCOccgLXWxxx0Gh4ee+cAcpM7D0Gn083dH3vnANqdzHkIOp125v7YOwew1z50HoJOZ7+977yGcwCtgz0Ya5wHoZMxxqC1X4AAjDFma2fHeRA6mc3WNo5y902Aj7eB21u7f+Kg0/awFD2N/XYbD3Z3oYEHrmv5CGAZAFY3ml42JfTf2lmGtc3m8VtArX91Xc89AIvbwPFr0sr6fbQO3V+X6MlaB3tYaa4hN3/vuewt1zWdA9DK/gDAAMcRrG2sY3WzicOs47o0PdTOOljdaGJtcwPm0c0fo4BF17WV6wIA8M3i4hKUrv3750NpCaPlMobTEhKd+LmYABYWuTHIul3sdw6RdbuP/Y6xWPj0yuUPXK/l5athibWf59ZchNbT//x5dtRFtvv48OTImGZizTUfS3n5MOjjubn7Csm7BuBbgdCMOUSavDN/9eq6j+W8fRo4P1drJEa9CWNk/8uPkIxpIk0uflKr3fW1pNePg+fnag07PDRrYZfwcGNIXhhjsaCsmfX5xwc8bQKf5Nvr11/JrbqiLN4wwIzWmATPHzwVY0wO6G2t8Yu1uJ0navGzWu23ENf6C/l/AOrWkOSOAAAAAElFTkSuQmCC);
+  }
+  .directory a {
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEwAACxMBAJqcGAAABTpJREFUeJzt2s9rHHUYx/HP88zO7OZX2cQareLBU7IVLyJ4EaJFS6ogIlKK+A948FDEi1DTFQUV1CJ49iBCFSse1DYR61EQqfbQNlFPFvzRkh9tkibZ3fk+HrRp2sb00GS+230+r1tmhvAJeXd3OhuAiIiIiIiIiIiIOp/c6IKhsYm7TO1eDeEOQLMiRt0sQQgGnUtKdubUgdGzsfe0s3UDGHrriz691P0iEPZB5P6iR22mYOFXEf2wZfkHv9WfuBh7T7u5LoChsWPPidh7Ah2MMWirGMI5GF6YrO/5PPaWdqJrv6iNjb+pIh932i8fAAQ6KKJHhg+OH4i9pZ2svgLUxiZegdgbMccUxcz2T9ZHD8Xe0Q4EAIbGjj6iwHGI3vCmsBMEhJYYHpqs7zkRe0tsAjOp1Sd+BPBA7DG0aQIszAKYNJHvYMlHk/XHf1nvQqmNHX0Mot8UPJCKZMEg8kkwfWmqvvuPtacUkKdj7aKCiAog+1TCyeH6xMjaU2qQh2PtoqLJdrH82NoIVMTujjmJiqYVsfDZ8OtHdwCAwuy22JOoaLJdmvIOAEjt4LjFnkNRBKgM642vow6lCPY8A3DMYLsYgGMCDJdij4itVOmNPWHTGQywgNBqwvLWBlfKgO8ARFCudtwHn1cJeROtSwtoXroIWH7taXX9FqDJLfEHTjdFkxRZXz+6B+9Z99XOdwBZOfaEwogoytVBZH0DVx13HUBa6Yk9oXBpTxVZb//q124D0LQMzbpiz4gi7e1H8t/P7jQAQbnP9xPwbNu/bwUuA8h6+6FZJfaMqLRURpJ1+Qsg66ki7a3GntEWkkoP3DwHEE1Q3rYdicMbv/+TZJXOD0BLGUpdfSh190HE3QvehjRJNw5A0wxJ2gUppRBVQG6NPxoWA6AJklIKaBJ7TvsSWT+ApNKDrLcKLfl5UOLV1QFIgkr1diTl7khzqGirAYgqKgM7oKXOfz5OV6zeFZX77+Qv3yEFgLS3iiT1/WDEKxVRpD18MOKVJpUe/v/YMeWTMd80SXnj55mKdvzTYNoA3/ydYwDOMQDnGIBzDMA5BuAcA3COATjHAJxjAM4xAOcYgHMMwDkG4BwDcI4BOMcAnGMAzjEA5xiAcwzAOQbgHANwjgE4xwCcYwDOMQDnGIBzDMA5BuAcA3COATjHAJxjAM4xAOcYgHMMwDkG4BwDcI4BOMcAnGMAzjEA5xiAcwzAOQbgHANwjgE4xwCcYwDOMQDnGIBzDMA5BuAcA3COATjHAJxjAM4xAOcUZrE3UCxm0JA3Y8+gSELegIbGSuwdFElorEBbKwuxd1AkzeVFaL6yhNBqxN5CBQvNFYTGEjRYaDYuTsfeQ4UyrMxPIwANBfSvvLGE5sJs7FVUkMbCLEJjGTD8qSL20+WDzcULsbfRFmsszqG5MAcAUNgJhclXqyfnp7Eydw4WQrSBtDUs5Fie+xvN+Zm1h7/UFvLDsLD6T7+1vICl87+jMT/Dm8MOEFoNNOansXT+LPLlxSvHgRlB+VMBgNrB8ZcBvL3eNxBNoKUUIglMihlNmyDkyFtNIOTrnjaz/ZP10UMlADiz88K7tVPbnoTIyHUXhhx5Y/1vQremYPbtFL5/H7j8YdDevbkAzwSEn6MuoyKcqKD8LOr1AKz5NPB0fXQmNxuB4Ui8bbS17LBYNnKy/ujc5SPrvqvvHJt4yiQ/AOiDxY2jrWLAD2JSP1Pf/fW15za8rbvvtYlaHmyXAMMABoIh2bKVtGkEaIlgFrDTQe341Kt7pmJvIiIiIqI28g8P/1ywWiSczgAAAABJRU5ErkJggg==)
+  }
+  .directory .size {
+    display: none;
+  }
+  span {
+   display: inline-block;
+  }
+
+  .size,
+  .modified {
+   width: 30%;
+   float: right;
+   text-align: right;
+  }
+
+  .modified {
+   width: 40%;
+  }
+
+  pre {
+   padding: 10px;
+   margin: 0;
+  }
+}

--- a/src/scss/helper-breakpoints.scss
+++ b/src/scss/helper-breakpoints.scss
@@ -1,0 +1,40 @@
+body {
+  min-width: 500px;
+  // mixin is being imported from "~dat-design/scss/responsive/breakpoints.scss":
+  @include breakpoint (xs) {
+    // sample rule here to demo:
+    // background: red;
+  }
+  @include breakpoint (sm) {
+    // sample rule here to demo:
+    // background: yellow;
+  }
+}
+
+// breakpoint testing helper
+body {
+  position: relative;
+  &:before {
+    position: absolute;
+    width: auto;
+    top: 0;
+    right: 50%;
+    font-size: 8px;
+    padding: 2px;
+    background-color: black;
+    color: white;
+    z-index: 100;
+    transition: all .1s ease-in-out;
+    content: '';
+    opacity: .8;
+    @include breakpoint (xs) {
+      content: 'We’re on breakpoint xs';
+      background-color: red;
+    }
+    @include breakpoint (sm) {
+      content: 'We’re on breakpoint sm';
+      background-color: yellow;
+      color: black;
+    }
+  }
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -91,26 +91,23 @@ li {
     height: 70%;
     border: 1px solid $color-neutral--20;
   }
+  /* render data */
+  table {
+    width: 100%;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    font-size: 14px;
+  }
+  table th,
+  table td {
+    text-align: left;
+    padding: 5px 10px;
+    color: $color-neutral;
+    min-height: 1.42857143;
+  }
 }
 
 #get_link {
   z-index: 10;
   position: absolute;
-}
-
-
-/* render data */
-table {
-  width: 100%;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  font-size: 14px;
-}
-
-table th,
-table td {
-  text-align: left;
-  padding: 5px 10px;
-  color: $color-neutral;
-  min-height: 1.42857143;
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -14,6 +14,7 @@
 @import "dat-header.scss";
 @import "file-system.scss";
 @import "file-queue.scss";
+@import "preview-display.scss";
 @import "helper-breakpoints.scss"; // this should move into dat-design – @kriesse
 
 
@@ -51,32 +52,6 @@ li {
 .breadcrumbs {
   margin-bottom: 1rem;
   min-height: 2em;
-}
-
-#display {
-  margin-bottom: 4rem;
-  img,
-  video {
-    margin: 10px;
-  }
-  iframe {
-    width: 100%;
-    height: 70%;
-    border: 1px solid $color-neutral--20;
-  }
-  table {
-    width: 100%;
-    margin-top: 10px;
-    margin-bottom: 10px;
-    font-size: 14px;
-  }
-  table th,
-  table td {
-    text-align: left;
-    padding: 5px 10px;
-    color: $color-neutral;
-    min-height: 1.42857143;
-  }
 }
 
 #get_link {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -101,12 +101,20 @@ li {
 
 /* header */
 
-.dat-header {
+.site-header {
   height: 4rem;
   padding-right: 1.5rem;
-//  padding-left: 6.5rem;
   background-color: $color-green--hover;
   color: $color-white;
+}
+
+.site-header__actions {
+  float: right;
+}
+
+.dat-import {
+  float: left;
+  margin-top: .5rem;
 }
 
 .dat-logo {
@@ -114,15 +122,6 @@ li {
   padding-top: .75rem;
   padding-left: 2.625rem;
   float: left;
-}
-
-.dat-header__actions {
-  float: right;
-}
-
-.dat-import {
-  float: left;
-  margin-top: .5rem;
 }
 
 // dat-button
@@ -142,7 +141,7 @@ li {
 
 // header for a single dat
 
-.dat-info-header {
+.dat-header {
   background-color: $color-neutral--04;
   border-bottom: 1px solid $color-neutral--10;
   font-size: .8125rem;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -14,8 +14,10 @@
 @import "dat-header.scss";
 @import "file-system.scss";
 @import "file-queue.scss";
-@import "helper-breakpoints.scss";
+@import "helper-breakpoints.scss"; // this should move into dat-design – @kriesse
 
+
+// global styles
 
 a, button, input {
   transition-property: background-color, color;
@@ -46,20 +48,6 @@ li {
   max-width: 1170px;
 }
 
-#speed {
-  display: none;
-  float: right;
-  line-height: 37px;
-  margin: 0 10px 0 0px;
-  padding: 0;
-  width: 320px;
-  span {
-    font-weight: normal;
-    font-size: .8125rem;
-    line-height: 37px;
-  }
-}
-
 .breadcrumbs {
   margin-bottom: 1rem;
   min-height: 2em;
@@ -76,7 +64,6 @@ li {
     height: 70%;
     border: 1px solid $color-neutral--20;
   }
-  /* render data */
   table {
     width: 100%;
     margin-top: 10px;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -10,6 +10,7 @@
 @import "~dat-design";
 @import "~dat-design/scss/base.scss";
 @import "site-header.scss";
+@import "status-bar.scss";
 @import "dat-header.scss";
 @import "file-system.scss";
 @import "file-queue.scss";
@@ -62,22 +63,6 @@ li {
 .breadcrumbs {
   margin-bottom: 1rem;
   min-height: 2em;
-}
-
-.status-bar {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  background-color: $color-neutral--04;
-  border-top: 1px solid $color-neutral--10;
-  font-size: .6875rem;
-  text-align: center;
-}
-.status-bar-status {
-  float: left;
-}
-.status-bar-stats {
-  float: right;
 }
 
 #display {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -145,6 +145,14 @@ li {
   }
 }
 
+// header for a single dat
+
+.dat-info-header {
+  background-color: $color-neutral--04;
+  border-bottom: 1px solid $color-neutral--10;
+  font-size: .8125rem;
+}
+
 .site-main {
   padding-top: 1.5rem;
 }
@@ -189,10 +197,19 @@ li {
 }
 
 .status-bar {
-  padding: .5rem;
-  padding-top: 1rem;
-  background-color: #f5fbf6;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background-color: $color-neutral--04;
+  border-top: 1px solid $color-neutral--10;
+  font-size: .6875rem;
   text-align: center;
+}
+.status-bar-status {
+  float: left;
+}
+.status-bar-stats {
+  float: right;
 }
 
 #display {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -54,43 +54,26 @@ body {
   }
 }
 
-
-a, button, input, .link {
+a, button, input {
   transition-property: background-color, color;
   transition-duration: $transition-duration;
   transition-timing-function: $transition-timing-function;
   cursor: pointer;
 }
 
-a,
-.link {
+a {
   color: $color-green;
 }
 
-
-a:hover, a:focus,
-.link:hover, .link:focus {
+a:hover, a:focus {
   color: $color-green--hover;
   outline: none;
 }
-
-//can be removed? @kriesse
-// .link {
-//   color: #959ba4;
-//   border: none;
-//   background: none;
-//   padding: .2rem 1rem .2rem 0;
-// }
-//
-// .link:before {
-//   content: '« '
-// }
 
 ul,
 li {
   @include list-plain;
 }
-
 
 /* box model */
 
@@ -98,21 +81,6 @@ li {
   margin: 0 auto;
   padding: .75rem 2rem;
   max-width: 1170px;
-}
-
-.site-main {
-  padding-top: 1.5rem;
-}
-
-.upload-file {
-  width: 100%;
-  min-height: 3em;
-  margin: 1rem auto;
-  padding: 1rem;
-  border: 3px dashed #959ba4;
-  border-radius: 1em;
-  color: #959ba4;
-  text-align: center;
 }
 
 #speed {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -9,6 +9,8 @@
  */
 @import "~dat-design";
 @import "~dat-design/scss/base.scss";
+@import "site-header.scss";
+@import "dat-header.scss";
 
 
 body {
@@ -96,73 +98,6 @@ li {
   margin: 0 auto;
   padding: .75rem 2rem;
   max-width: 1170px;
-}
-
-
-/* header */
-
-.site-header {
-  height: 4rem;
-  padding-right: 1.5rem;
-  background-color: $color-green--hover;
-  color: $color-white;
-}
-
-.site-header__actions {
-  float: right;
-}
-
-.dat-import {
-  float: left;
-  margin-top: .5rem;
-}
-
-.dat-logo {
-  width: 6.5rem;
-  padding-top: .75rem;
-  padding-left: 2.625rem;
-  float: left;
-}
-
-// dat-button
-.dat-button {
-  float: left;
-  padding-top: 1.15rem;
-  padding-bottom: 1.15rem;
-  margin-right: 3rem;
-  button {
-    &:hover, &:focus, &:active {
-      color: $color-neutral--04;
-      outline: none;
-      cursor: pointer;
-    }
-  }
-}
-
-// header for a single dat
-
-.dat-header {
-  background-color: $color-neutral--04;
-  border-bottom: 1px solid $color-neutral--10;
-  font-size: .8125rem;
-}
-
-.share-link {
-  font-size: 1.375rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.dat-details {
-  padding-top: 1.5rem;
-  padding-bottom: .25rem;
-}
-
-.dat-detail {
-  display: inline-block;
-  margin-right: 1.5rem;
-  color: $color-neutral--80;
 }
 
 .site-main {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -155,6 +155,17 @@ li {
   text-overflow: ellipsis;
 }
 
+.dat-details {
+  padding-top: 1.5rem;
+  padding-bottom: .25rem;
+}
+
+.dat-detail {
+  display: inline-block;
+  margin-right: 1.5rem;
+  color: $color-neutral--80;
+}
+
 .site-main {
   padding-top: 1.5rem;
 }
@@ -170,14 +181,6 @@ li {
   text-align: center;
 }
 
-#hyperdrive-size {
-  float: left;
-}
-
-#peers {
-  display: inline-block;
-}
-
 #speed {
   display: none;
   float: right;
@@ -187,9 +190,8 @@ li {
   width: 320px;
   span {
     font-weight: normal;
-    font-size: 13px;
+    font-size: .8125rem;
     line-height: 37px;
-    margin-left: 10px;
   }
 }
 

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -148,6 +148,13 @@ li {
   font-size: .8125rem;
 }
 
+.share-link {
+  font-size: 1.375rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .site-main {
   padding-top: 1.5rem;
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -11,48 +11,10 @@
 @import "~dat-design/scss/base.scss";
 @import "site-header.scss";
 @import "dat-header.scss";
+@import "file-system.scss";
+@import "file-queue.scss";
+@import "helper-breakpoints.scss";
 
-
-body {
-  min-width: 500px;
-  // mixin is being imported from "~dat-design/scss/responsive/breakpoints.scss":
-  @include breakpoint (xs) {
-    // sample rule here to demo:
-    // background: red;
-  }
-  @include breakpoint (sm) {
-    // sample rule here to demo:
-    // background: yellow;
-  }
-}
-
-// breakpoint testing helper
-body {
-  position: relative;
-  &:before {
-    position: absolute;
-    width: auto;
-    top: 0;
-    right: 50%;
-    font-size: 8px;
-    padding: 2px;
-    background-color: black;
-    color: white;
-    z-index: 100;
-    transition: all .1s ease-in-out;
-    content: '';
-    opacity: .8;
-    @include breakpoint (xs) {
-      content: 'We’re on breakpoint xs';
-      background-color: red;
-    }
-    @include breakpoint (sm) {
-      content: 'We’re on breakpoint sm';
-      background-color: yellow;
-      color: black;
-    }
-  }
-}
 
 a, button, input {
   transition-property: background-color, color;
@@ -136,92 +98,6 @@ li {
   position: absolute;
 }
 
-/* file queue */
-
-#file-queue {
-  clear: both;
-  li {
-    padding: 10px;
-    padding-left: 35px;
-    font-size: 14px;
-    color: $color-neutral--50;
-    border-bottom: 1px solid #f0f0f0;
-    background-color: $color-neutral--04;
-    .progress {
-      float: right;
-      width: 30%;
-      &.error {
-        color: $color-danger;
-        text-align: right;
-        padding: 0;
-      }
-    }
-  }
-}
-
-/* archive ui */
-
-#hyperdrive-ui {
-  clear: both;
-}
-
-#yo-fs {
-  color: $color-neutral;
-  padding: 0;
-  h1 a {
-    margin: 5px;
-  }
-  ul {
-    margin: 0;
-    padding: 0;
-  }
-  li {
-    list-style-type: none;
-    a {
-      display: block;
-      padding: 10px;
-      font-size: 14px;
-      border-bottom: 1px solid $color-neutral--20;
-      background-size: 15px;
-      background-repeat: no-repeat;
-      background-position: 10px 11px;
-      padding-left: 35px;
-      color: $color-neutral;
-      text-decoration: none;
-      &:hover {
-        background-color: $color-neutral--04;
-      }
-    }
-  }
-  .file a {
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEwAACxMBAJqcGAAABQZJREFUeJzt3M9rnEUcx/HPzPNskk3TTTZNVFQKIkIOEnr3pBQv2osiuKWpJ1Ei4kF7EPwnPIiIt5jmLPQkpV1wS089ay6ihJCy+dHEza/dZ/PMeEilYos2mZmdZ/f7eR1DmOfL5s3u7LOzAYiIiIhIHBVy8fqdOxeM0a9bixkoNQFlk5DXi2F9Z+uny5cufR97jtMKEsCtxt33APsVoGdDrF8kyyt/2Gpl7KN+jcBrAI1Go5ohXQDwts91i2x55XcAqm8j0L4WqtfvTXVs+jME/fEfsWq7tffd0o0bH8ae5KS8BFCv19OjtPujUnjVx3r9qT8j8BKASUe+0MBrPtbqb/0XgXMAN2/eG4cxX/oYZjD0VwTOAaiR7H1oXfExzODonwjcAzDqLR+DDJ7+iMB9D6DNBQ9zDKjiR+AcgDF4zscgg6vYETgHoLUu+RhksBU3Am83guj/FDMCBtBTxYuAAfRcsSJgAFEUJwIGEE0xImAAUcWPgAFEFzcCBlAI8SJgAIURJwIGUCi9j4ABONLK90PY2wgYgKNSmgZYtXcRMABH5aHhQCv3JgIG4Ojs6JmAq4ePgAE4OlMuY7g0FPAKYSNgAB48Wz0X+ArhImAAHoyOjGBqvBr4KmEiYACeTI1P4NzZ8cBX8R8BA/BoujqJ56emkeiQX4L2GwED8KwyOoaXX3gRz0xUMRRsc+gvghB3McTTSmOyMoHJygSO8hzZURd5bgBYn5dRsPgagNM3khlAYGmSIE2CvSSUXRfgS4BwDEA4BiBc9D1A62Av9ghRVUbHol4/egBrmxuxR4iqcj5uAHwJEI4BCMcAhGMAwkXfBM6cfyn2CKLxGUA4BiAcAxCOAQjHAIRjAMIxAOEYgHAMQLjodwJ5HoDnAWKPEBXPA1BUDEA4BiAcAxAu+iaQ5wHi4jOAcAxAOAYgHAMQjgEIxwCEYwDCMQDhGIBw0e8E8jwAzwPEHiEqngegqBiAcAxAOAYgXPRNIM8DxMVnAOEYgHAMQDgGIBwDEI4BCMcAhGMAwjEA4aLfCeR5AJ4HiD1CVDwPQFExAOEYgHAMQLjom0CeB4iLzwDCMQDhGIBwDEA4BiAcAxCOAQjHAIRjAMIxAOEYgHAMQDgGIBwDEI4BCOccgLXWxxx0Gh4ee+cAcpM7D0Gn083dH3vnANqdzHkIOp125v7YOwew1z50HoJOZ7+977yGcwCtgz0Ya5wHoZMxxqC1X4AAjDFma2fHeRA6mc3WNo5y902Aj7eB21u7f+Kg0/awFD2N/XYbD3Z3oYEHrmv5CGAZAFY3ml42JfTf2lmGtc3m8VtArX91Xc89AIvbwPFr0sr6fbQO3V+X6MlaB3tYaa4hN3/vuewt1zWdA9DK/gDAAMcRrG2sY3WzicOs47o0PdTOOljdaGJtcwPm0c0fo4BF17WV6wIA8M3i4hKUrv3750NpCaPlMobTEhKd+LmYABYWuTHIul3sdw6RdbuP/Y6xWPj0yuUPXK/l5athibWf59ZchNbT//x5dtRFtvv48OTImGZizTUfS3n5MOjjubn7Csm7BuBbgdCMOUSavDN/9eq6j+W8fRo4P1drJEa9CWNk/8uPkIxpIk0uflKr3fW1pNePg+fnag07PDRrYZfwcGNIXhhjsaCsmfX5xwc8bQKf5Nvr11/JrbqiLN4wwIzWmATPHzwVY0wO6G2t8Yu1uJ0navGzWu23ENf6C/l/AOrWkOSOAAAAAElFTkSuQmCC);
-  }
-  .directory a {
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEwAACxMBAJqcGAAABTpJREFUeJzt2s9rHHUYx/HP88zO7OZX2cQareLBU7IVLyJ4EaJFS6ogIlKK+A948FDEi1DTFQUV1CJ49iBCFSse1DYR61EQqfbQNlFPFvzRkh9tkibZ3fk+HrRp2sb00GS+230+r1tmhvAJeXd3OhuAiIiIiIiIiIiIOp/c6IKhsYm7TO1eDeEOQLMiRt0sQQgGnUtKdubUgdGzsfe0s3UDGHrriz691P0iEPZB5P6iR22mYOFXEf2wZfkHv9WfuBh7T7u5LoChsWPPidh7Ah2MMWirGMI5GF6YrO/5PPaWdqJrv6iNjb+pIh932i8fAAQ6KKJHhg+OH4i9pZ2svgLUxiZegdgbMccUxcz2T9ZHD8Xe0Q4EAIbGjj6iwHGI3vCmsBMEhJYYHpqs7zkRe0tsAjOp1Sd+BPBA7DG0aQIszAKYNJHvYMlHk/XHf1nvQqmNHX0Mot8UPJCKZMEg8kkwfWmqvvuPtacUkKdj7aKCiAog+1TCyeH6xMjaU2qQh2PtoqLJdrH82NoIVMTujjmJiqYVsfDZ8OtHdwCAwuy22JOoaLJdmvIOAEjt4LjFnkNRBKgM642vow6lCPY8A3DMYLsYgGMCDJdij4itVOmNPWHTGQywgNBqwvLWBlfKgO8ARFCudtwHn1cJeROtSwtoXroIWH7taXX9FqDJLfEHTjdFkxRZXz+6B+9Z99XOdwBZOfaEwogoytVBZH0DVx13HUBa6Yk9oXBpTxVZb//q124D0LQMzbpiz4gi7e1H8t/P7jQAQbnP9xPwbNu/bwUuA8h6+6FZJfaMqLRURpJ1+Qsg66ki7a3GntEWkkoP3DwHEE1Q3rYdicMbv/+TZJXOD0BLGUpdfSh190HE3QvehjRJNw5A0wxJ2gUppRBVQG6NPxoWA6AJklIKaBJ7TvsSWT+ApNKDrLcKLfl5UOLV1QFIgkr1diTl7khzqGirAYgqKgM7oKXOfz5OV6zeFZX77+Qv3yEFgLS3iiT1/WDEKxVRpD18MOKVJpUe/v/YMeWTMd80SXnj55mKdvzTYNoA3/ydYwDOMQDnGIBzDMA5BuAcA3COATjHAJxjAM4xAOcYgHMMwDkG4BwDcI4BOMcAnGMAzjEA5xiAcwzAOQbgHANwjgE4xwCcYwDOMQDnGIBzDMA5BuAcA3COATjHAJxjAM4xAOcYgHMMwDkG4BwDcI4BOMcAnGMAzjEA5xiAcwzAOQbgHANwjgE4xwCcYwDOMQDnGIBzDMA5BuAcA3COATjHAJxjAM4xAOcUZrE3UCxm0JA3Y8+gSELegIbGSuwdFElorEBbKwuxd1AkzeVFaL6yhNBqxN5CBQvNFYTGEjRYaDYuTsfeQ4UyrMxPIwANBfSvvLGE5sJs7FVUkMbCLEJjGTD8qSL20+WDzcULsbfRFmsszqG5MAcAUNgJhclXqyfnp7Eydw4WQrSBtDUs5Fie+xvN+Zm1h7/UFvLDsLD6T7+1vICl87+jMT/Dm8MOEFoNNOansXT+LPLlxSvHgRlB+VMBgNrB8ZcBvL3eNxBNoKUUIglMihlNmyDkyFtNIOTrnjaz/ZP10UMlADiz88K7tVPbnoTIyHUXhhx5Y/1vQremYPbtFL5/H7j8YdDevbkAzwSEn6MuoyKcqKD8LOr1AKz5NPB0fXQmNxuB4Ui8bbS17LBYNnKy/ujc5SPrvqvvHJt4yiQ/AOiDxY2jrWLAD2JSP1Pf/fW15za8rbvvtYlaHmyXAMMABoIh2bKVtGkEaIlgFrDTQe341Kt7pmJvIiIiIqI28g8P/1ywWiSczgAAAABJRU5ErkJggg==)
-  }
-  .directory .size {
-    display: none;
-  }
-  span {
-   display: inline-block;
-  }
-
-  .size,
-  .modified {
-   width: 30%;
-   float: right;
-   text-align: right;
-  }
-
-  .modified {
-   width: 40%;
-  }
-
-  pre {
-   padding: 10px;
-   margin: 0;
-  }
-}
 
 /* render data */
 table {

--- a/src/scss/preview-display.scss
+++ b/src/scss/preview-display.scss
@@ -1,0 +1,25 @@
+#display {
+  margin-bottom: 4rem;
+  img,
+  video {
+    margin: 10px;
+  }
+  iframe {
+    width: 100%;
+    height: 70%;
+    border: 1px solid $color-neutral--20;
+  }
+  table {
+    width: 100%;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    font-size: 14px;
+  }
+  table th,
+  table td {
+    text-align: left;
+    padding: 5px 10px;
+    color: $color-neutral;
+    min-height: 1.42857143;
+  }
+}

--- a/src/scss/site-header.scss
+++ b/src/scss/site-header.scss
@@ -1,0 +1,39 @@
+/* header */
+
+.site-header {
+  height: 4rem;
+  padding-right: 1.5rem;
+  background-color: $color-green--hover;
+  color: $color-white;
+}
+
+.site-header__actions {
+  float: right;
+}
+
+.dat-import {
+  float: left;
+  margin-top: .5rem;
+}
+
+.dat-logo {
+  width: 6.5rem;
+  padding-top: .75rem;
+  padding-left: 2.625rem;
+  float: left;
+}
+
+// dat-button
+.dat-button {
+  float: left;
+  padding-top: 1.15rem;
+  padding-bottom: 1.15rem;
+  margin-right: 3rem;
+  button {
+    &:hover, &:focus, &:active {
+      color: $color-neutral--04;
+      outline: none;
+      cursor: pointer;
+    }
+  }
+}

--- a/src/scss/status-bar.scss
+++ b/src/scss/status-bar.scss
@@ -1,0 +1,15 @@
+.status-bar {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background-color: $color-neutral--04;
+  border-top: 1px solid $color-neutral--10;
+  font-size: .6875rem;
+  text-align: center;
+}
+.status-bar-status {
+  float: left;
+}
+.status-bar-stats {
+  float: right;
+}


### PR DESCRIPTION
Styles for dat-header.

Clean up main.css:
- Remove unused styles
- Rename unclear class names
- Namespace global styles
- Used classes, not IDs when possible
- Group chunks of scss in separate files. Moving forward, this should make it easier to move styles that we want to reuse elsewhere over to dat-design.