### PR TITLE
 use 'var' instead of 'let' because of es2020 support on the node side

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -18,7 +18,7 @@ if (module.parent) {
   module.exports = {
     app: app,
     getServerComponent: (component) => {
-      let components = {
+      var components = {
         // register server-side components here:
         hyperdrive: require('../../server/components/hyperdrive')
       }

--- a/client/js/components/hyperdrive/index.js
+++ b/client/js/components/hyperdrive/index.js
@@ -1,7 +1,7 @@
 const from = require('from2')
 
 if (module.parent) {
-  let hyperdriveRenderer = require('./../../app.js').getServerComponent('hyperdrive')
+  var hyperdriveRenderer = require('./../../app.js').getServerComponent('hyperdrive')
 
   module.exports = function (state, prev, send) {
     return hyperdriveRenderer({entries: state.archive.entries})

--- a/client/js/models/archive.js
+++ b/client/js/models/archive.js
@@ -6,8 +6,8 @@ const path = require('path')
 const hyperdriveImportQueue = require('hyperdrive-import-queue')
 var drop = require('drag-drop')
 
-let noop = function () {}
-let drive = hyperdrive(memdb())
+var noop = function () {}
+var drive = hyperdrive(memdb())
 
 module.exports = {
   namespace: 'archive',
@@ -123,7 +123,7 @@ module.exports = {
         var entries = {}
         stream.on('data', function (entry) {
           entries[entry.name] = entry
-          let dir = path.dirname(entry.name)
+          var dir = path.dirname(entry.name)
           if (!entries[dir]) {
             entries[dir] = {
               type: 'directory',

--- a/server/haus.js
+++ b/server/haus.js
@@ -40,7 +40,7 @@ function Haus (opts) {
 }
 
 Haus.prototype.getArchive = function (key, cb) {
-  let archive = this.cache.get(key)
+  var archive = this.cache.get(key)
   if (!archive) {
     archive = this.drive.createArchive(key, {file: this.file})
     this.cache.set(archive.discoveryKey.toString('hex'), archive)

--- a/server/router.js
+++ b/server/router.js
@@ -16,7 +16,7 @@ try {
 } catch (e) {
   console.warn('To enable rtc swarm, run: npm i electron-webrtc')
 }
-let haus = Haus({ wrtc })
+var haus = Haus({ wrtc })
 
 // serve old pre-choo client-side-only app for migration work:
 router.on('/migrate', {
@@ -32,7 +32,7 @@ router.on('/migrate', {
 // landing page
 router.on('/', {
   get: function (req, res, params) {
-    let state = getDefaultAppState()
+    var state = getDefaultAppState()
     sendSPA('/', res, state)
   }
 })
@@ -40,17 +40,17 @@ router.on('/', {
 // new choo-based archive route:
 router.on('/:archiveKey', {
   get: function (req, res, params) {
-    let state = getDefaultAppState()
-    let key
+    var state = getDefaultAppState()
+    var key
     try {
       key = encoding.decode(params.archiveKey)
     } catch (e) {
       state.archive.error = {message: e.message}
       return sendSPA('/:archiveKey', res, state)
     }
-    let archive = haus.getArchive(key)
-    let cancelled
-    let clear = setTimeout(() => {
+    var archive = haus.getArchive(key)
+    var cancelled
+    var clear = setTimeout(() => {
       cancelled = true
       sendSPA('/:archiveKey', res, state)
     }, 3000)
@@ -109,7 +109,7 @@ router.on('/public/img/:asset', {
 
 /* helpers */
 function getDefaultAppState () {
-  let state = {}
+  var state = {}
   app._store._models.forEach((model) => {
     assert.equal(typeof model, 'object', 'getDefaultAppState: model must be an object')
     assert.equal(typeof model.namespace, 'string', 'getDefaultAppState: model must have a namespace property that is a string')


### PR DESCRIPTION
In irc:

```
@ogd> 
yoshuawuyts: does es2020 error if you use es2015+ language features that arent included in es2020? or does it just ignore them?

19:51 Y<yoshuawuyts> 
it ignores it as long as the parser is able to parse it
19:51 would be cool if we could make it fail tho, but that would probs require writing a bunch of babel plugins

19:52 O<@ogd> 
yoshuawuyts: gotcha. so its up to the user to make sure they only use the right features

19:53 Y<yoshuawuyts> 
yup

19:53 O<@ogd> 
clkao: so in that case we should just be careful to only use modern language features that are included in es2020 for now :D
```