### PR TITLE
single file preview panel

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -7,6 +7,7 @@ const app = choo()
 app.model(require('./models/archive'))
 app.model(require('./models/user'))
 app.model(require('./models/help'))
+app.model(require('./models/preview'))
 
 // define routes:
 app.router((route) => [

--- a/client/js/components/hyperdrive/index.js
+++ b/client/js/components/hyperdrive/index.js
@@ -1,4 +1,5 @@
 const from = require('from2')
+var noop = function () {}
 
 if (module.parent) {
   var hyperdriveRenderer = require('./../../app.js').getServerComponent('hyperdrive')
@@ -22,6 +23,8 @@ if (module.parent) {
     return require('hyperdrive-ui')(null, {root: state.archive.cwd, entries: state.archive.entries}, (ev, entry) => {
       if (entry.type === 'directory') {
         send('archive:update', {root: entry.name})
+      } else {
+        send('preview:file', {archiveKey: state.archive.key, entry: entry.name}, noop)
       }
       return false
     })

--- a/client/js/components/preview/index.js
+++ b/client/js/components/preview/index.js
@@ -1,0 +1,21 @@
+const html = require('choo/html')
+const button = require('../../elements/button')
+
+const preview = (state, prev, send) => {
+  const isOpen = state.preview.isPanelOpen ? 'open' : ''
+  const fileName = state.preview.fileName
+  return html`<section id="preview" class="panel ${isOpen}">
+    <div class="panel-contents">
+      ${fileName}
+      ${button({
+        klass: 'close-panel',
+        text: 'close',
+        click: () => {
+          send('preview:closePanel')
+        }
+      })}
+    </div>
+  </preview>`
+}
+
+module.exports = preview

--- a/client/js/elements/button/index.js
+++ b/client/js/elements/button/index.js
@@ -6,6 +6,5 @@ module.exports = (props, click) => {
   return html`
     <button onclick=${props.click} class="btn ${props.klass || 'btn--green'}">
       ${props.text}
-    </button>
-  `
+    </button>`
 }

--- a/client/js/models/archive.js
+++ b/client/js/models/archive.js
@@ -134,6 +134,9 @@ module.exports = {
           send('archive:update', {entries, size}, noop)
         })
       })
+    },
+    readFile: function (data, state, send, done) {
+      console.log('TODO: read file from archive, send back to preview panel')
     }
   }
 }

--- a/client/js/models/preview.js
+++ b/client/js/models/preview.js
@@ -1,0 +1,36 @@
+var noop = function () {}
+var defaultState = {
+  isPanelOpen: false,
+  isLoading: false,
+  archiveKey: null,
+  fileName: null,
+  fileContents: null,
+  error: null
+}
+
+module.exports = {
+  namespace: 'preview',
+  state: defaultState,
+  reducers: {
+    updateFile: (data, state) => {
+      return {
+        archiveKey: data.archiveKey || state.archiveKey,
+        fileName: data.entry || state.entry
+      }
+    },
+    openPanel: (data, state) => {
+      return {isPanelOpen: true}
+    },
+    closePanel: (data, state) => {
+      return defaultState
+    }
+  },
+  effects: {
+    file: (data, state, send, done) => {
+      send('preview:updateFile', data, noop)
+      send('preview:openPanel', {}, noop)
+      send('archive:readFile', data, noop)
+      // TODO: state.preview.isPanelOpen + corresponding loading indicator in ui
+    }
+  }
+}

--- a/client/js/pages/archive/index.js
+++ b/client/js/pages/archive/index.js
@@ -6,6 +6,7 @@ const header = require('../../components/header')
 const error = require('../../elements/error')
 const hyperdriveStats = require('../../elements/hyperdrive-stats')
 const prettyBytes = require('pretty-bytes')
+const preview = require('../../components/preview')
 
 const archivePage = (state, prev, send) => {
   // TODO: style the error handling
@@ -54,6 +55,7 @@ const archivePage = (state, prev, send) => {
           </div>
         </div>
       </div>
+      ${preview(state, prev, send)}
     </div>`
 }
 

--- a/client/scss/main.scss
+++ b/client/scss/main.scss
@@ -14,9 +14,12 @@
 @import "dat-header.scss";
 @import "file-system.scss";
 @import "file-queue.scss";
-@import "preview-display.scss";
+@import "panel.scss"; //
+@import "preview.scss"; // TODO: this should move into dat-design - @lauren
 @import "landing-page.scss";
-@import "helper-breakpoints.scss"; // this should move into dat-design – @kriesse
+@import "helper-breakpoints.scss"; // TODO: this should move into dat-design – @kriesse
+
+@import "preview-display.scss"; // TODO: delete this after choo migration
 
 
 // global styles

--- a/client/scss/panel.scss
+++ b/client/scss/panel.scss
@@ -1,0 +1,12 @@
+.panel {
+  position: absolute;
+  top: 0;
+  right: -100%;
+  width: 100%;
+  height: 100%;
+  transition: right 250ms $transition-timing-function;
+
+  &.open {
+    right: 0;
+  }
+}

--- a/client/scss/preview-display.scss
+++ b/client/scss/preview-display.scss
@@ -1,3 +1,4 @@
+/* TODO: delete this file after choo migration is complete */
 #display {
   margin-bottom: 4rem;
   img,

--- a/client/scss/preview.scss
+++ b/client/scss/preview.scss
@@ -1,0 +1,3 @@
+#preview {
+  background-color: white;
+}


### PR DESCRIPTION
this should get @Kriesse moving forward with styling the preview panel.

to view the panel: only webrtc-to-webrtc peers are working at the moment, so you'll need to create a new archive via drag and drop in the ui. click on the resulting file name that gets rendered. panel will slide out. will continue this later but wanted to get styling moving forward.

relevant files: 
html can be modified in `client/js/components/preview`
scss in `scss/preview.scss`