### PR TITLE
Build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ data/*
 public/css/*
 public/js/app.js
 public/js/app.min.js
+public/js/app.min.*.js
+public/js/browser-warning.*.js
+server/page-debug.js
 .tmp-deploy
 npm-debug.log
 REVISION

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 data/*
 public/css/*
 public/js/app.js
+public/js/app.min.js
 .tmp-deploy
 npm-debug.log
 REVISION

--- a/bin/version-assets.js
+++ b/bin/version-assets.js
@@ -2,26 +2,29 @@
 var fs = require('fs')
 var Version = require('node-version-assets')
 
-// productionize `index.html` by updating asset references
+// productionize `server/page.js` by updating asset references
 // `main.css` -> 'main.min.css'
 // `app.js` -> `app.min.js`
-// re-name original, un-productionized `index.html` to `debug.html`
-var index = fs.readFileSync('index.html', 'utf8')
-fs.renameSync('index.html', 'debug.html')
-var prod = index
+// re-name original, un-productionized `page.js` to `page-debug.html`
+var page = 'server/page.js'
+var pageContents = fs.readFileSync(page, 'utf8')
+fs.renameSync(page, 'server/page-debug.js')
+
+var prod = pageContents
              .replace(/public\/css\/main.css/gmi, 'public/css/main.min.css')
              .replace(/public\/js\/app.js/gmi, 'public/js/app.min.js')
-fs.writeFileSync('index.html', prod, 'utf8')
+fs.writeFileSync(page, prod, 'utf8')
 
 // version `app.min.js` and `main.min.js` by appending md5 hash to filename
-// & update references to files in `index.html`
+// & update references to files in `server/page.js`
 var versionInstance = new Version({
   assets: [
     'public/js/app.min.js',
+    'public/js/browser-warning.js',
     'public/css/main.min.css'
   ],
   grepFiles: [
-    'index.html'
+    page
   ],
   keepOriginal: true,
   keepOldVersions: false

--- a/client/scss/main.scss
+++ b/client/scss/main.scss
@@ -1,6 +1,6 @@
 /**
  * Use awesome syntax of `node-sass-magic-importer` to import scss modules
- * "@import ~xxx" resolves to a node module named `xxx`
+ * See import `dat-design` rule below for example.
  * If there's no file path specified after module name, it resolves to the file
  * defined by the imported package.json's `style` property
  *
@@ -19,4 +19,4 @@
 @import "imports/preview"; // TODO: this should move into dat-design - @lauren
 @import "imports/landing-page";
 @import "imports/preview-display"; // TODO: delete this after choo migration
-@import "imports/introjs-custom"; 
+@import "imports/introjs-custom";

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dat-design": "^1.4.1",
     "drag-drop": "^2.11.0",
     "es2040": "^1.2.3",
-    "minifier": "^0.7.1",
+    "minifier": "^0.8.0",
     "nightwatch": "^0.9.5",
     "node-sass": "^3.8.0",
     "node-sass-magic-importer": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "relative-date": "^1.1.3",
     "render-data": "^2.2.0",
     "serialize-javascript": "^1.3.0",
-    "server-router": "^2.1.0"
+    "server-router": "^2.1.0",
+    "uparams": "^1.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "watch-server": "nodemon --watch server --watch client",
     "build": "npm run build-js && npm run build-css",
     "build-css": "node-sass --importer node_modules/node-sass-magic-importer client/scss/main.scss public/css/main.css",
-    "build-js": "browserify client/js/app.js > public/js/app.js",
+    "build-js": "browserify -g yo-yoify -g es2020 client/js/app.js > public/js/app.js",
     "minify": "npm run minify-css && npm run minify-js",
     "minify-css": "minify public/css/main.css > public/css/main.min.css",
     "minify-js": "uglifyjs public/js/app.js -o public/js/app.min.js",
@@ -44,6 +44,7 @@
     "chromedriver": "^2.21.2",
     "dat-design": "^1.4.1",
     "drag-drop": "^2.11.0",
+    "es2020": "^1.1.9",
     "minidux": "^1.0.1",
     "minifier": "^0.7.1",
     "nightwatch": "^0.9.5",
@@ -56,7 +57,8 @@
     "speedometer": "^1.0.0",
     "standard": "^7.1.2",
     "uglify-js": "^2.7.0",
-    "watchify": "~3.6.0"
+    "watchify": "~3.6.0",
+    "yo-yoify": "^3.4.1"
   },
   "dependencies": {
     "choo": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "test:e2e:firefox": "nightwatch --env firefox,firefox",
     "watch": "npm run watch-js & npm run watch-css & npm run watch-server",
     "watch-css": "nodemon -e scss -x \"npm run build-css\"",
-    "watch-js": "watchify client/js/app.js -o public/js/app.js",
+    "watch-js": "watchify -g es2040 client/js/app.js -o public/js/app.js",
     "watch-server": "nodemon --watch server --watch client",
     "build": "npm run build-js && npm run build-css",
     "build-css": "node-sass --importer node_modules/node-sass-magic-importer client/scss/main.scss public/css/main.css",
-    "build-js": "browserify -g yo-yoify -g es2020 client/js/app.js > public/js/app.js",
+    "build-js": "browserify -g es2040 client/js/app.js > public/js/app.js",
     "minify": "npm run minify-css && npm run minify-js",
     "minify-css": "minify public/css/main.css > public/css/main.min.css",
     "minify-js": "uglifyjs public/js/app.js -o public/js/app.min.js",
@@ -44,8 +44,7 @@
     "chromedriver": "^2.21.2",
     "dat-design": "^1.4.1",
     "drag-drop": "^2.11.0",
-    "es2020": "^1.1.9",
-    "minidux": "^1.0.1",
+    "es2040": "^1.2.3",
     "minifier": "^0.7.1",
     "nightwatch": "^0.9.5",
     "node-sass": "^3.8.0",
@@ -57,8 +56,7 @@
     "speedometer": "^1.0.0",
     "standard": "^7.1.2",
     "uglify-js": "^2.7.0",
-    "watchify": "~3.6.0",
-    "yo-yoify": "^3.4.1"
+    "watchify": "~3.6.0"
   },
   "dependencies": {
     "choo": "^3.2.0",


### PR DESCRIPTION
some updates/fixes here for production:

* fix broken build caused by removing the browserify transform here: https://github.com/datproject/dat.land/commit/fd2b004fa90b39697d2687ea08f32645557340b7
* now that the browserify build transform has been brought back, it needed to be switched from using `es2020` to `es2040` to support object destructuring syntax
* the css minifier was also borked up by a comment i added that was explaining how the scss magic importer worked (why was it looking at commented-out code tho?)
* closes #181 (updated the minification versioning script and set up a ?debug=true path in the router that returns the unminified resources for debugging)
