### PR TITLE
Download single archive file as zip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 sudo: required
 dist: trusty
 node_js:
-  - 4
   - 6
 
 before_install:

--- a/client/js/components/preview/index.js
+++ b/client/js/components/preview/index.js
@@ -27,7 +27,13 @@ const preview = (state, prev, send) => {
         </div>
       </div>
       <div class="panel-header__action-group">
-        <button class="dat-header-action">Download</button>
+        ${button({
+          klass: 'dat-header-action',
+          text: 'Download',
+          click: () => {
+            send('archive:download', {entryName})
+          }
+        })}
         <a href="dat://${state.archive.key}" class="dat-header-action">Open in Desktop App</a>
       </div>
     </div>

--- a/client/js/models/archive.js
+++ b/client/js/models/archive.js
@@ -241,11 +241,15 @@ module.exports = {
       done(readStream)
     },
     download: function (data, state, send, done) {
+      // XXX: TODO: failover msg when dat is shared from cli, no file contents available
       const archive = state.instance
       const zip = new Jszip()
+      var zipName
       if (data && data.entryName) {
+        zipName = data.entryName
         zip.file(data.entryName, archive.createFileReadStream(data.entryName))
       } else {
+        zipName = state.key
         Object.keys(state.entries).sort().forEach((key) => {
           const entry = state.entries[key]
           if (entry.type === 'directory') {
@@ -257,7 +261,7 @@ module.exports = {
       }
       zip.generateAsync({type: 'blob'})
       .then((content) => {
-        saveAs(content, `${state.key}.zip`)
+        saveAs(content, `${zipName}.zip`)
         done()
       })
     }

--- a/client/js/models/archive.js
+++ b/client/js/models/archive.js
@@ -243,14 +243,18 @@ module.exports = {
     download: function (data, state, send, done) {
       const archive = state.instance
       const zip = new Jszip()
-      Object.keys(state.entries).sort().forEach((key) => {
-        const entry = state.entries[key]
-        if (entry.type === 'directory') {
-          // XXX: empty directories need to be created explicitly
-        } else {
-          zip.file(key, archive.createFileReadStream(key))
-        }
-      })
+      if (data && data.entryName) {
+        zip.file(data.entryName, archive.createFileReadStream(data.entryName))
+      } else {
+        Object.keys(state.entries).sort().forEach((key) => {
+          const entry = state.entries[key]
+          if (entry.type === 'directory') {
+            // XXX: empty directories need to be created explicitly
+          } else {
+            zip.file(key, archive.createFileReadStream(key))
+          }
+        })
+      }
       zip.generateAsync({type: 'blob'})
       .then((content) => {
         saveAs(content, `${state.key}.zip`)


### PR DESCRIPTION
This was the forgotten item from dat.land roadmap for alpha. https://github.com/datproject/dat.land-roadmap/issues/32

We do need to do some kind of messaging for dat-cli-shared archives whose contents are not available. I'll open a separate issue around that because I'm not sure what the right user experience/messaging should be.