### PR TITLE
better messaging for unavailable single file .zip downloads

### DIFF
--- a/client/js/components/preview/index.js
+++ b/client/js/components/preview/index.js
@@ -32,7 +32,7 @@ const preview = (state, prev, send) => {
           icon: './public/img/download.svg',
           text: 'Download',
           click: () => {
-            send('archive:download', {entryName})
+            send('archive:downloadAsZip', {entryName})
           }
         })}
         <a href="dat://${state.archive.key}" class="dat-header-action">

--- a/client/js/models/archive.js
+++ b/client/js/models/archive.js
@@ -265,7 +265,7 @@ module.exports = {
             if (!archive.isEntryDownloaded(entry)) {
               doFinalizeZip = false // if one entry is missing, send failoverMsg()
             } else {
-              zip.file(key, archive.createFileReadStream(key))
+              zip.file(entry.name, archive.createFileReadStream(key))
             }
           }
         })

--- a/client/js/models/archive.js
+++ b/client/js/models/archive.js
@@ -246,7 +246,7 @@ module.exports = {
       const zip = new Jszip()
       var zipName
       if (data && data.entryName) {
-        archive.get(data.entryName, {timeout: 1000}, function (err, entry) {
+        archive.get(data.entryName, {timeout: 1500}, function (err, entry) {
           if (err) return failoverMsg()
           if (!archive.isEntryDownloaded(entry)) return failoverMsg()
           zipName = data.entryName
@@ -262,11 +262,10 @@ module.exports = {
           if (entry.type === 'directory') {
             // XXX: empty directories need to be created explicitly
           } else {
-            if (!archive.isEntryDownloaded(entry)) {
-              doFinalizeZip = false // if one entry is missing, send failoverMsg()
-            } else {
-              zip.file(entry.name, archive.createFileReadStream(key))
-            }
+            archive.get(entry.name, {timeout: 1500}, function (err, entry) {
+              if (err) return doFinalizeZip = false
+              zip.file(entry.name, archive.createFileReadStream(data.entryName))
+            })
           }
         })
         if (!doFinalizeZip) return failoverMsg()

--- a/client/js/pages/archive/index.js
+++ b/client/js/pages/archive/index.js
@@ -29,7 +29,7 @@ const archivePage = (state, prev, send) => {
       <div id="dat-info" class="dat-header">
         <div class="container">
           <div class="dat-header__actions">
-            <button class="dat-header-action" onclick=${() => send('archive:download')}>
+            <button class="dat-header-action" onclick=${() => send('archive:downloadAsZip')}>
               <div class="btn__icon-wrapper">
                 <img src="./public/img/download.svg" class="btn__icon-img">
                 <span class="btn__icon-text">Download</span>

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "dat-encoding": "^3.0.0",
     "datland-swarm-defaults": "^1.0.2",
     "discovery-swarm": "^4.0.2",
+    "es6-promise": "^3.3.1",
     "extend": "^3.0.0",
     "file-saver": "^1.3.2",
     "from2": "^2.3.0",


### PR DESCRIPTION
right now, when an cli-shared archive is not available for download as a zip, we don't do any messaging to the user. the user just clicks "download" and nothing happens. same for single file "download as zip" as well inside of the preview pane. this PR detects via the `archive.isEntryDownloaded()` method whether a file is available and pops up an alert message if not.