### PR TITLE
Items in display should be streamed in

### DIFF
--- a/client/js/components/display/index.js
+++ b/client/js/components/display/index.js
@@ -14,7 +14,7 @@ module.exports = function (state, prev, send) {
   if (state.preview.error && !prev.preview.error) {
     return fourohfour({
       header: state.preview.error.message,
-      body: `${state.preview.entryName} cannot be rendered.`,
+      body: state.preview.error.body || `${state.preview.entryName} cannot be rendered.`,
       link: false
     })
   }
@@ -30,9 +30,9 @@ module.exports = function (state, prev, send) {
     archive.get(entryName, {timeout: 3000}, function (err, entry) {
       if (err) {
         if (err.code && err.code === 'ETIMEDOUT') {
-          return send('preview:update', {error: new Error('Loading...')})
+          return send('preview:update', {error: {message: 'Looking for peers...', body: 'It seems to be taking a long time.'}})
         } else {
-          return send('preview:update', {error: new Error(err)})
+          return send('preview:update', {error: err})
         }
       }
       var stream = archive.createFileReadStream(entryName)

--- a/client/js/components/display/index.js
+++ b/client/js/components/display/index.js
@@ -30,27 +30,20 @@ module.exports = function (state, prev, send) {
     archive.get(entryName, {timeout: 3000}, function (err, entry) {
       if (err) {
         if (err.code && err.code === 'ETIMEDOUT') {
-          return send('preview:update', {error: new Error('Could not find any peer sources.')})
+          return send('preview:update', {error: new Error('Loading...')})
         } else {
           return send('preview:update', {error: new Error(err)})
         }
       }
-      // XXX TODO: handle progress and timeout for download
-      archive.download(entry, function (err) {
-        if (archive.isEntryDownloaded(entry)) {
-          var stream = archive.createFileReadStream(entryName)
-          renderData.render({
-            name: entryName,
-            createReadStream: function () { return stream }
-          }, display, function (error) {
-            if (error) {
-              var message = 'Unsupported filetype'
-              if (error.message === 'premature close') message = 'Could not find any peer sources.'
-              send('preview:update', {error: new Error(message)})
-            }
-          })
-        } else {
-          send('preview:update', {error: new Error(err)})
+      var stream = archive.createFileReadStream(entryName)
+      renderData.render({
+        name: entryName,
+        createReadStream: function () { return stream }
+      }, display, function (error) {
+        if (error) {
+          var message = 'Unsupported filetype'
+          if (error.message === 'premature close') message = 'Could not find any peer sources.'
+          send('preview:update', {error: new Error(message)})
         }
       })
     })


### PR DESCRIPTION
We really need to make sure that we are streaming in the data, this is one of the big benefits of dat is that we can stream in only say 10 rows of a 300gb csv (in theory ;p) without downloading the entire file first into memory.

This also has a placeholder for loading, telling the user that 'hey, im still looking to download this file but its taking a while to find a peer' which is a more accurate state for when it can't initially get the file metadata after 3 seconds. I'm sure we will continue to iterate on the loading language and add the new loading icons as soon we as we can get https://github.com/shama/bel/pull/31 merged.



