### PR TITLE
disable default behavior when using hyperdrive renderer. fixes #307

### DIFF
--- a/client/js/components/hyperdrive/index.js
+++ b/client/js/components/hyperdrive/index.js
@@ -11,6 +11,7 @@ module.exports = function (state, prev, send) {
       return true
     } else {
       send('preview:file', {archiveKey: state.archive.key, entry: entry}, noop)
+      return false
     }
   }
 


### PR DESCRIPTION
by returning false we bypass the error block: https://github.com/karissa/yo-fs/blob/master/index.js#L69