### PR TITLE
Disable download button if there are no peers

### DIFF
--- a/client/js/components/display/index.js
+++ b/client/js/components/display/index.js
@@ -35,15 +35,19 @@ module.exports = function (state, prev, send) {
           return send('preview:update', {error: err})
         }
       }
+      send('preview:update', {isLoading: false})
       var stream = archive.createFileReadStream(entryName)
       renderData.render({
         name: entryName,
         createReadStream: function () { return stream }
       }, display, function (error) {
         if (error) {
+          var update = {}
           var message = 'Unsupported filetype'
           if (error.message === 'premature close') message = 'Could not find any peer sources.'
-          send('preview:update', {error: new Error(message)})
+          else update.isLoading = false // Allow downloads for unsupported files
+          update.error = new Error(message)
+          send('preview:update', update)
         }
       })
     })

--- a/client/js/components/preview/index.js
+++ b/client/js/components/preview/index.js
@@ -31,6 +31,7 @@ const preview = (state, prev, send) => {
           klass: 'dat-header-action',
           icon: './public/img/download.svg',
           text: 'Download',
+          disabled: state.preview.isLoading,
           click: () => {
             send('archive:downloadAsZip', {entryName})
           }

--- a/client/js/elements/button/index.js
+++ b/client/js/elements/button/index.js
@@ -5,12 +5,12 @@ module.exports = (props, click) => {
   if (typeof click === 'function') props.click = click
   var child
   if (props.icon) {
-    child = html`<div class="btn__icon-wrapper"><img class="btn__icon-img" src="${props.icon}" /><span class="btn__icon-text">${props.text}</span></div>`
+    child = html`<div class="btn__icon-wrapper ${props.disabled ? 'disabled' : ''}"><img class="btn__icon-img" src="${props.icon}" /><span class="btn__icon-text">${props.text}</span></div>`
   } else {
     child = props.text
   }
   return html`
-    <button onclick=${props.click} class="${props.klass}">
+    <button onclick=${props.click} class="${props.klass}" ${props.disabled ? 'disabled' : ''}>
       ${child}
     </button>`
 }

--- a/client/js/models/preview.js
+++ b/client/js/models/preview.js
@@ -13,10 +13,11 @@ module.exports = {
   state: module.parent ? defaultState : window.dl.init__dehydratedAppState.preview,
   reducers: {
     update: (data, state) => {
+      if (!data.error || data.entry) data.isLoading = false
       return data
     },
     openPanel: (data, state) => {
-      return {isPanelOpen: true}
+      return {isPanelOpen: true, isLoading: true}
     },
     closePanel: (data, state) => {
       return defaultState

--- a/client/js/pages/archive/index.js
+++ b/client/js/pages/archive/index.js
@@ -32,8 +32,8 @@ const archivePage = (state, prev, send) => {
       <div id="dat-info" class="dat-header">
         <div class="container">
           <div class="dat-header__actions">
-            <button class="dat-header-action" onclick=${() => send('archive:downloadAsZip')}>
-              <div class="btn__icon-wrapper">
+            <button class="dat-header-action" onclick=${() => send('archive:downloadAsZip')} ${state.archive.numPeers ? '' : 'disabled'}>
+              <div class="btn__icon-wrapper ${state.archive.numPeers ? '' : 'disabled'}">
                 <img src="./public/img/download.svg" class="btn__icon-img">
                 <span class="btn__icon-text">Download</span>
               </div>

--- a/client/scss/imports/_add-button.scss
+++ b/client/scss/imports/_add-button.scss
@@ -39,7 +39,7 @@
   display: flex;
   flex-wrap: nowrap;
   flex-direction: row;
-  &:hover, &:focus {
+  &:not(.disabled):hover, &:not(.disabled):focus {
     .btn__icon-img {
       opacity: 1;
     }

--- a/client/scss/imports/_base.scss
+++ b/client/scss/imports/_base.scss
@@ -12,6 +12,9 @@ a, button, input[type="submit"] {
   &:focus {
     outline: none;
   }
+  &:disabled {
+    cursor: default;
+  }
 }
 
 a {

--- a/client/scss/imports/_dat-header.scss
+++ b/client/scss/imports/_dat-header.scss
@@ -24,12 +24,15 @@
   line-height: 1.25;
   background-color: transparent;
   color: $color-neutral--80;
-  &:hover, &:focus {
+  &:not([disabled]):hover, &:not([disabled]):focus {
     color: $color-neutral;
   }
   &:first-child {
     margin-left: 0;
     padding-left: 0;
+  }
+  &:disabled {
+    opacity: 0.5;
   }
 }
 


### PR DESCRIPTION
Disable the download button when archive is not downloadable. This uses `state.archive.numPeers`. It seems like that is the easiest way to tell if the archive is currently downloadable.

Other notes:

* Dims button to 50% opacity (to match icon)
* Had to add the disabled class to `btn__icon-wrapper`. Not ideal but couldn't see other ways to do it.

Yay front end!